### PR TITLE
feat(commerce): 결제 로직 및 서킷 브레이커 관련 테스트코드 작성 및 모니터링 추가

### DIFF
--- a/kotlin-springboot-practice-commerce/README.md
+++ b/kotlin-springboot-practice-commerce/README.md
@@ -34,7 +34,7 @@ Build, Execution, Deployment > Build Tools > Gradle > Run tests using > IntelliJ
 Beeceptor Console > Mocking Rules 메뉴에서 아래 규칙을 등록해야 합니다.
 
 - Base URL: `https://commerce.free.beeceptor.com` (본인의 Beeceptor 도메인으로 변경 필요)
-- Target URL Path: `/api/v1/payment`
+- Target URL Path: `/api/v1/payments`
 - Method: `POST`
 
 #### Case 1: 결제 승인 성공 (Success)

--- a/kotlin-springboot-practice-commerce/core/core-api/build.gradle.kts
+++ b/kotlin-springboot-practice-commerce/core/core-api/build.gradle.kts
@@ -14,4 +14,5 @@ dependencies {
 
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j")
+    implementation("io.github.resilience4j:resilience4j-micrometer")
 }

--- a/kotlin-springboot-practice-commerce/core/core-api/src/main/kotlin/io/dodn/commerce/core/api/config/RestClientConfig.kt
+++ b/kotlin-springboot-practice-commerce/core/core-api/src/main/kotlin/io/dodn/commerce/core/api/config/RestClientConfig.kt
@@ -13,10 +13,10 @@ class RestClientConfig {
     fun restClient(): RestClient {
         val requestFactory = JdkClientHttpRequestFactory(
             HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(3)) // Connection Timeout
+                .connectTimeout(Duration.ofSeconds(3))
                 .build(),
         )
-        requestFactory.setReadTimeout(Duration.ofSeconds(30)) // Read Timeout
+        requestFactory.setReadTimeout(Duration.ofSeconds(3))
 
         return RestClient.builder()
             .requestFactory(requestFactory)

--- a/kotlin-springboot-practice-commerce/core/core-api/src/main/resources/application.yml
+++ b/kotlin-springboot-practice-commerce/core/core-api/src/main/resources/application.yml
@@ -32,7 +32,7 @@ resilience4j:
         base-config: default
 
         sliding-window-type: COUNT_BASED    # 집계 슬라이딩 윈도우 크기 (횟수 기반)
-        sliding-window-size: 20             # CLOSED 상태에서 최근 20회 호출을 기준으로 실패율(failureRateThreshold) 계산
+        sliding-window-size: 10             # CLOSED 상태에서 최근 10회 호출을 기준으로 실패율(failureRateThreshold) 계산
         minimum-number-of-calls: 10         # 집계에 필요한 최소 호출 수
         failure-rate-threshold: 50          # 실패율 임계값: 실패 50% 이상 시 OPEN 상태로 전환
         slow-call-duration-threshold: 5000  # 5000ms 이상 소요 시 실패로 간주

--- a/kotlin-springboot-practice-commerce/core/core-api/src/test/kotlin/io/dodn/commerce/core/api/client/BeeceptorPaymentClientTest.kt
+++ b/kotlin-springboot-practice-commerce/core/core-api/src/test/kotlin/io/dodn/commerce/core/api/client/BeeceptorPaymentClientTest.kt
@@ -1,0 +1,60 @@
+package io.dodn.commerce.core.api.client
+
+import io.dodn.commerce.ContextTest
+import io.dodn.commerce.core.config.TestRestClientConfig
+import io.dodn.commerce.core.domain.PaymentCommand
+import io.dodn.commerce.core.support.error.CoreException
+import io.dodn.commerce.core.support.error.ErrorType
+import io.github.resilience4j.circuitbreaker.CircuitBreaker
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry
+import io.micrometer.core.instrument.MeterRegistry
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo
+import org.springframework.test.web.client.response.MockRestResponseCreators.withServerError
+
+@Import(TestRestClientConfig::class)
+class BeeceptorPaymentClientTest(
+    private val beeceptorPaymentClient: BeeceptorPaymentClient,
+    private val circuitBreakerRegistry: CircuitBreakerRegistry,
+    private var mockServer: MockRestServiceServer,
+) : ContextTest() {
+    @Test
+    fun `외부 API가 반복적으로 실패하면 서킷 브레이커가 OPEN 되고 Fallback 예외가 발생한다`() {
+        // given
+        val command = PaymentCommand(
+            externalPaymentKey = "payment_key_test",
+            orderId = 1L,
+            amount = 10000L,
+        )
+
+        val circuitBreaker = circuitBreakerRegistry.circuitBreaker("beeceptor-payment")
+
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.CLOSED)
+
+        for (i in 1..20) {
+            mockServer.expect(requestTo("https://commerce.free.beeceptor.com/api/v1/payments"))
+                .andRespond(withServerError())
+        }
+
+        // when (최소 호출 수 10회, 실패율 50%)
+        for (i in 1..10) {
+            try {
+                beeceptorPaymentClient.requestPayment(command)
+            } catch (e: Exception) {
+            }
+        }
+
+        // then
+        assertThat(circuitBreaker.state).isEqualTo(CircuitBreaker.State.OPEN)
+
+        val exception = assertThrows(CoreException::class.java) {
+            beeceptorPaymentClient.requestPayment(command)
+        }
+        assertThat(exception.errorType).isEqualTo(ErrorType.PAYMENT_EXTERNAL_API_UNAVAILABLE)
+    }
+}

--- a/kotlin-springboot-practice-commerce/core/core-api/src/test/kotlin/io/dodn/commerce/core/config/TestRestClientConfig.kt
+++ b/kotlin-springboot-practice-commerce/core/core-api/src/test/kotlin/io/dodn/commerce/core/config/TestRestClientConfig.kt
@@ -1,0 +1,24 @@
+package io.dodn.commerce.core.config
+
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.web.client.MockRestServiceServer
+import org.springframework.web.client.RestClient
+
+@TestConfiguration
+class TestRestClientConfig {
+
+    @Bean
+    fun mockRestServiceServer(builder: RestClient.Builder): MockRestServiceServer {
+        return MockRestServiceServer.bindTo(builder).build()
+    }
+
+    @Bean
+    @Primary
+    fun testRestClient(builder: RestClient.Builder, server: MockRestServiceServer): RestClient {
+        return builder
+            .baseUrl("https://commerce.free.beeceptor.com/api")
+            .build()
+    }
+}

--- a/kotlin-springboot-practice-commerce/core/core-api/src/test/kotlin/io/dodn/commerce/core/domain/PaymentServiceTest.kt
+++ b/kotlin-springboot-practice-commerce/core/core-api/src/test/kotlin/io/dodn/commerce/core/domain/PaymentServiceTest.kt
@@ -5,6 +5,9 @@ import io.dodn.commerce.core.enums.OrderState
 import io.dodn.commerce.core.enums.PaymentMethod
 import io.dodn.commerce.core.enums.PaymentState
 import io.dodn.commerce.core.enums.PointType
+import io.dodn.commerce.core.enums.TransactionType
+import io.dodn.commerce.core.support.error.CoreException
+import io.dodn.commerce.core.support.error.ErrorType
 import io.dodn.commerce.storage.db.core.OrderEntity
 import io.dodn.commerce.storage.db.core.OrderRepository
 import io.dodn.commerce.storage.db.core.PaymentEntity
@@ -14,6 +17,7 @@ import io.dodn.commerce.storage.db.core.PointBalanceRepository
 import io.dodn.commerce.storage.db.core.PointHistoryRepository
 import io.dodn.commerce.storage.db.core.TransactionHistoryRepository
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
@@ -116,5 +120,176 @@ class PaymentServiceTest(
             assertThat(it.externalPaymentKey).isEqualTo("PG-EXT-KEY")
             assertThat(it.amount).isEqualByComparingTo(paidAmount)
         }
+    }
+
+    @Test
+    @Transactional
+    fun `결제 실패(fail) 호출 시 실패 히스토리가 기록된다`() {
+        // given
+        val userId = 1234L
+        val orderPrice = BigDecimal.valueOf(10000)
+        val orderKey = "ORDER-KEY-FAIL"
+
+        // order in CREATED
+        val order = orderRepository.save(
+            OrderEntity(
+                userId = userId,
+                orderKey = orderKey,
+                name = "실패 테스트 주문",
+                totalPrice = orderPrice,
+                state = OrderState.CREATED,
+            ),
+        )
+
+        // payment status: IN_PROGRESS
+        val payment = paymentRepository.save(
+            PaymentEntity(
+                userId = userId,
+                orderId = order.id,
+                originAmount = orderPrice,
+                ownedCouponId = 0,
+                couponDiscount = BigDecimal.ZERO,
+                usedPoint = BigDecimal.ZERO,
+                paidAmount = orderPrice,
+                state = PaymentState.IN_PROGRESS,
+                externalPaymentKey = "PG-EXT-KEY",
+            ),
+        )
+
+        // when
+        paymentService.fail(orderKey, "PAYMENT_REJECTED", "잔액 부족")
+
+        // then
+        val histories = transactionHistoryRepository.findAll()
+        assertThat(histories).hasSize(1)
+        val history = histories[0]
+
+        assertThat(history.type).isEqualTo(TransactionType.PAYMENT_FAIL)
+        assertThat(history.paymentId).isEqualTo(payment.id)
+        assertThat(history.message).contains("잔액 부족")
+        assertThat(history.amount).isEqualByComparingTo(BigDecimal.valueOf(-1))
+    }
+
+    @Test
+    @Transactional
+    fun `결제 검증(prepare) 시 요청 금액과 실제 결제 금액이 다르면 예외가 발생한다`() {
+        // given
+        val userId = 1234L
+        val orderPrice = BigDecimal.valueOf(10000)
+        val wrongAmount = BigDecimal.valueOf(5000) // 금액 변조 시도
+        val orderKey = "ORDER-KEY-MISMATCH"
+
+        val order = orderRepository.save(
+            OrderEntity(
+                userId = userId,
+                orderKey = orderKey,
+                name = "금액 불일치 테스트",
+                totalPrice = orderPrice,
+                state = OrderState.CREATED,
+            ),
+        )
+
+        paymentRepository.save(
+            PaymentEntity(
+                userId = userId,
+                orderId = order.id,
+                originAmount = orderPrice,
+                ownedCouponId = 0,
+                couponDiscount = BigDecimal.ZERO,
+                usedPoint = BigDecimal.ZERO,
+                paidAmount = orderPrice, // DB에 저장된 금액은 10000
+                state = PaymentState.READY,
+            ),
+        )
+
+        // when & then
+        val exception = assertThrows(CoreException::class.java) {
+            paymentService.preparePayment(orderKey, "PG-KEY-TEMP", wrongAmount)
+        }
+
+        assertThat(exception.errorType).isEqualTo(ErrorType.PAYMENT_AMOUNT_MISMATCH)
+    }
+
+    @Test
+    @Transactional
+    fun `결제 검증(prepare) 시 결제 상태가 READY가 아니면 예외가 발생한다`() {
+        // given
+        val userId = 1234L
+        val orderPrice = BigDecimal.valueOf(10000)
+        val orderKey = "ORDER-KEY-INVALID-STATE"
+
+        val order = orderRepository.save(
+            OrderEntity(
+                userId = userId,
+                orderKey = orderKey,
+                name = "상태 검증 테스트",
+                totalPrice = orderPrice,
+                state = OrderState.CREATED,
+            ),
+        )
+
+        // 이미 IN_PROGRESS 상태 (중복 호출 상황 등)
+        paymentRepository.save(
+            PaymentEntity(
+                userId = userId,
+                orderId = order.id,
+                originAmount = orderPrice,
+                ownedCouponId = 0,
+                couponDiscount = BigDecimal.ZERO,
+                usedPoint = BigDecimal.ZERO,
+                paidAmount = orderPrice,
+                state = PaymentState.IN_PROGRESS,
+                externalPaymentKey = "PG-KEY-TEMP",
+            ),
+        )
+
+        // when & then
+        val exception = assertThrows(CoreException::class.java) {
+            paymentService.preparePayment(orderKey, "PG-KEY-TEMP", orderPrice)
+        }
+
+        assertThat(exception.errorType).isEqualTo(ErrorType.PAYMENT_INVALID_STATE)
+    }
+
+    @Test
+    @Transactional
+    fun `결제 완료(complete) 시 결제 상태가 IN_PROGRESS가 아니면 예외가 발생한다`() {
+        // given
+        val userId = 1234L
+        val orderPrice = BigDecimal.valueOf(10000)
+        val orderKey = "ORDER-KEY-NOT-PROGRESS"
+
+        val order = orderRepository.save(
+            OrderEntity(
+                userId = userId,
+                orderKey = orderKey,
+                name = "완료 상태 검증 테스트",
+                totalPrice = orderPrice,
+                state = OrderState.CREATED,
+            ),
+        )
+
+        // prepare 단계를 거치지 않고(READY) 바로 complete 호출 시도
+        paymentRepository.save(
+            PaymentEntity(
+                userId = userId,
+                orderId = order.id,
+                originAmount = orderPrice,
+                ownedCouponId = 0,
+                couponDiscount = BigDecimal.ZERO,
+                usedPoint = BigDecimal.ZERO,
+                paidAmount = orderPrice,
+                state = PaymentState.READY,
+            ),
+        )
+
+        val paymentResult = PaymentResult("PG-KEY", PaymentMethod.CARD, "APPROVE", "성공")
+
+        // when & then
+        val exception = assertThrows(CoreException::class.java) {
+            paymentService.completePayment(orderKey, paymentResult)
+        }
+
+        assertThat(exception.errorType).isEqualTo(ErrorType.PAYMENT_INVALID_STATE)
     }
 }

--- a/kotlin-springboot-practice-commerce/docker-compose.yml
+++ b/kotlin-springboot-practice-commerce/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3.8"
+services:
+
+  prometheus:
+    image: prom/prometheus:v2.51.2
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./support/monitoring/infra/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    environment:
+      - TZ=Asia/Seoul
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./support/monitoring/infra/grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - ./support/monitoring/infra/grafana/datasources:/etc/grafana/provisioning/datasources
+    environment:
+      - TZ=Asia/Seoul

--- a/kotlin-springboot-practice-commerce/storage/db-core/src/main/kotlin/io/dodn/commerce/storage/db/core/PaymentEntity.kt
+++ b/kotlin-springboot-practice-commerce/storage/db-core/src/main/kotlin/io/dodn/commerce/storage/db/core/PaymentEntity.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Table
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
+// 외부에 따라 달라지는 데이터들을 담는 테이블
 @Entity
 @Table(
     name = "payment",
@@ -17,7 +18,6 @@ import java.time.LocalDateTime
         Index(name = "udx_order_id", columnList = "orderId", unique = true),
     ],
 )
-// 외부에 따라 달라지는 데이터들을 담는 테이블
 class PaymentEntity(
     val userId: Long,
     val orderId: Long,

--- a/kotlin-springboot-practice-commerce/support/monitoring/infra/grafana/dashboards/commerce/commerce-payment-api-server-circuitbreaker-dashboard.json
+++ b/kotlin-springboot-practice-commerce/support/monitoring/infra/grafana/dashboards/commerce/commerce-payment-api-server-circuitbreaker-dashboard.json
@@ -1,0 +1,141 @@
+{
+  "title": "Commerce Payment Circuit Breaker",
+  "uid": "commerce-circuit-breaker",
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "refresh": "5s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "OPEN",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "commerce-prometheus" },
+      "targets": [
+        {
+          "expr": "(resilience4j_circuitbreaker_state{name=\"beeceptor-payment\"} == bool 1) or vector(0)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "red" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "red", "value": null }]
+          },
+          "unit": "none",
+          "min": 0
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "wideLayout": true
+      }
+    },
+    {
+      "id": 2,
+      "title": "HALF_OPEN",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "commerce-prometheus" },
+      "targets": [
+        {
+          "expr": "(resilience4j_circuitbreaker_state{name=\"beeceptor-payment\"} == bool 2) or vector(0)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "orange" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "orange", "value": null }]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "wideLayout": true
+      }
+    },
+    {
+      "id": 3,
+      "title": "CLOSED",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 16, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "commerce-prometheus" },
+      "targets": [
+        {
+          "expr": "(resilience4j_circuitbreaker_state{name=\"beeceptor-payment\"} == bool 0) or vector(0)",
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "fixed", "fixedColor": "green" },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          }
+        }
+      },
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "textMode": "value",
+        "wideLayout": true
+      }
+    },
+    {
+      "id": 4,
+      "title": "상세 지표 (실패율 및 호출량)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 6 },
+      "datasource": { "type": "prometheus", "uid": "commerce-prometheus" },
+      "targets": [
+        {
+          "expr": "resilience4j_circuitbreaker_failure_rate{name=\"beeceptor-payment\"}",
+          "legendFormat": "실패율 (%)",
+          "refId": "A"
+        },
+        {
+          "expr": "irate(resilience4j_circuitbreaker_calls_seconds_count{name=\"beeceptor-payment\"}[1m])",
+          "legendFormat": "총 호출량 (TPS)",
+          "refId": "B"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity": 10, "gradientMode": "none", "hideFrom": { "legend": false, "tooltip": false, "viz": false }, "lineInterpolation": "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": { "type": "linear" }, "showPoints": "auto", "spanNulls": false, "stacking": { "group": "A", "mode": "none" }, "thresholdsStyle": { "mode": "off" } },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      }
+    }
+  ]
+}

--- a/kotlin-springboot-practice-commerce/support/monitoring/infra/grafana/dashboards/dashboard.yml
+++ b/kotlin-springboot-practice-commerce/support/monitoring/infra/grafana/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboard provider"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: true

--- a/kotlin-springboot-practice-commerce/support/monitoring/infra/grafana/datasources/datasource.yml
+++ b/kotlin-springboot-practice-commerce/support/monitoring/infra/grafana/datasources/datasource.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: prometheus
+
+datasources:
+  - name: commerce-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/kotlin-springboot-practice-commerce/support/monitoring/infra/prometheus/prometheus.yml
+++ b/kotlin-springboot-practice-commerce/support/monitoring/infra/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 10s
+  evaluation_interval: 10s
+
+scrape_configs:
+  - job_name: 'commerce-api'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['host.docker.internal:8082']


### PR DESCRIPTION
## Task

- [x] 결제 로직 및 서킷 브레이커 관련 테스트코드 작성
- [x] 서킷 브레이커 모니터링을 위해 grafana, prometheus 설정

## 모니터링 결과

모니터링 지표로 서킷 브레이커 관련 상태값(3개), 실패률, 호출량 추가

<img width="966" height="492" alt="circuit-breeaker-monitoring-metrics" src="https://github.com/user-attachments/assets/c6027f65-9653-4091-84a8-d5ca79645cda" />
